### PR TITLE
Chomping values in log_and_shout's options argument to prevent logfile co

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -95,6 +95,16 @@ module Deployinator
 
       raise "Must have stack" unless options[:stack]
 
+      # newlines in any of these will corrupt the logfile, so strip them out
+      newoptions = {}
+      options.each do |key, value|
+        if value.is_a? String
+          value = value.chomp
+        end
+        newoptions[key] = value
+      end
+      options = newoptions
+
       options[:env] ||= "PROD"
       options[:nice_env] = nicify_env(options[:env])
       options[:user] ||= @username


### PR DESCRIPTION
So I managed to track down the cause of [this error](https://github.com/etsy/deployinator/issues/5).  It turns out I was storing a build ID that had newlines in it, which corrupted the logfile.  Since I'm assuming it's always a bad idea to store newlines in a logfile, I wrote a patch to chomp all of them.  I don't do Ruby very much, so let me know if there's a better way to do this patch.
