### PR TITLE
Issue #3 | Using open4 instead of open3 to track process exit status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "sinatra"
 gem "json"
 gem "pony"
 gem "tlsmail"
+gem "open4"
 
 group :test do
   gem 'nokogiri', '~> 1.4.7' # for ruby 1.8.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    capybara (1.0.0)
+    capybara (1.0.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      selenium-webdriver (~> 0.2.0)
+      selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    childprocess (0.2.0)
+    childprocess (0.2.1)
       ffi (~> 1.0.6)
     ffi (1.0.9)
     i18n (0.6.0)
@@ -21,22 +21,23 @@ GEM
     mime-types (1.16)
     mustache (0.99.4)
     nokogiri (1.4.7)
+    open4 (1.1.0)
     polyglot (0.3.2)
     pony (1.3)
       mail (> 2.0)
-    rack (1.3.1)
+    rack (1.3.2)
     rack-test (0.6.1)
       rack (>= 1.0)
     rake (0.9.2)
     rubyzip (0.9.4)
-    selenium-webdriver (0.2.2)
-      childprocess (>= 0.1.9)
+    selenium-webdriver (2.4.0)
+      childprocess (>= 0.2.1)
       ffi (>= 1.0.7)
       json_pure
       rubyzip
     sinatra (1.2.6)
       rack (~> 1.1)
-      tilt (>= 1.2.2, < 2.0)
+      tilt (< 2.0, >= 1.2.2)
     tilt (1.3.2)
     tlsmail (0.0.1)
     treetop (1.4.10)
@@ -53,6 +54,7 @@ DEPENDENCIES
   json
   mustache
   nokogiri (~> 1.4.7)
+  open4
   pony
   rack
   rake

--- a/helpers.rb
+++ b/helpers.rb
@@ -64,7 +64,7 @@ module Deployinator
       start = Time.now.to_i
       log_and_stream "<div class='command'><h4>Running #{cmd}</h4><p class='output'>"
       time = Benchmark.measure do
-        Open3.popen3(cmd) do |inn, out, err|
+        ret_code = Open4.popen4(cmd) do |pid, inn, out, err|
           output = ""
           until out.eof?
             # raise "Timeout" if output.empty? && Time.now.to_i - start > 300
@@ -79,6 +79,7 @@ module Deployinator
           log_and_stream(output) unless output.empty?
           log_and_stream("<span class='stderr'>STDERR: #{err.read}</span><br>") unless err.eof?
         end
+        raise 'process_failed' unless ret_code == 0
       end
       log_and_stream "</p>"
       log_and_stream "<h5>Time: #{time}</h5></div>"

--- a/lib/libraries.rb
+++ b/lib/libraries.rb
@@ -13,6 +13,7 @@ $LOAD_PATH.unshift Deployinator.root("lib") unless $LOAD_PATH.include? Deployina
 require 'pony'
 require 'sinatra/base'
 require 'mustache/sinatra'
+require 'open4'
 
 # Silence mustache warnings
 module Mustache::Sinatra::Helpers

--- a/stacks/demo.rb
+++ b/stacks/demo.rb
@@ -32,12 +32,15 @@ module Deployinator
         send(git_cmd, stack, "sh -c")
 
         git_bump_version stack, ""
-        
+
         build = demo_head_build
 
-        run_cmd %Q{echo "ssh host do_something"}
-
-        log_and_stream "Done!<br>"
+        begin
+          run_cmd %Q{echo "ssh host do_something"}
+          log_and_stream "Done!<br>"
+        rescue
+          log_and_stream "Failed!<br>"
+        end
 
         # log this deploy / timing
         log_and_shout(:old_build => old_build, :build => build, :send_email => true)


### PR DESCRIPTION
Fixed this issue by using open4 instead of open3 to in run_cmd. The build should fail in case of an error now. 
