### PR TITLE
Changed how iframe height is retrieved, so autoscroll would work on Chrome, Firefox, Safari.

### DIFF
--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -155,7 +155,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                     setInterval(function() {
                         if (!autoScroll) { return; }
                         $("iframe").each(function() {
-                            this.contentWindow.scrollTo(0, this.contentDocument.height);
+                            this.contentWindow.scrollTo(0, this.contentDocument.body.clientHeight);
                         });
                     }, 200);
                 });


### PR DESCRIPTION
Autoscroll wasn't working for me, so I updated this bit of javascript so it would work.
