### PR TITLE
Modularize graphite calls using TCPSocket

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -335,7 +335,7 @@ module Deployinator
         end
 
         # ping graphite!
-        graphite("deploys.#{args["stack"]}.#{env} 1")
+        graphite_plot("deploys.#{args["stack"]}.#{env} 1")
       end
     end
 

--- a/helpers/graphite.rb
+++ b/helpers/graphite.rb
@@ -1,11 +1,13 @@
-module Helpers
-  module GraphiteHelpers
-  require 'socket'
-    def graphite_plot(logString)
-      if Deployinator.graphite_host
-        s = TCPSocket.new(Deployinator.graphite_host,Deployinator.graphite_port || 2003)
-        s.write "#{logString} #{Time.now.to_i}\n"
-        s.close
+module Deployinator
+  module Helpers
+    module GraphiteHelpers
+    require 'socket'
+      def graphite_plot(logString)
+        if Deployinator.graphite_host
+          s = TCPSocket.new(Deployinator.graphite_host,Deployinator.graphite_port || 2003)
+          s.write "#{logString} #{Time.now.to_i}\n"
+          s.close
+        end
       end
     end
   end


### PR DESCRIPTION
Put graphite calls into a helper and check graphite_host is defined
before trying to open a socket.
