### PR TITLE
Making github.com the default github host.

### DIFF
--- a/helpers/git.rb
+++ b/helpers/git.rb
@@ -38,7 +38,7 @@ module Deployinator
       end
 
       def github_host
-        Deployinator.github_host
+        Deployinator.github_host || "github.com"
       end
 
       def github_url


### PR DESCRIPTION
Hey,

Just starting to use Deployinator, looks like a great project.  Since most people are probably using github.com as their github host, I think it makes sense to default the github host to github.com.  Thanks!
