### PR TITLE
Setting deploy form class to environment name.

### DIFF
--- a/templates/generic_single_push.mustache
+++ b/templates/generic_single_push.mustache
@@ -13,7 +13,7 @@
 {{#environments}}
     <div class="stack-box">
         <h2><span>{{number}}</span>{{title}}</h2>
-        <form action="/dispatch" method="post">
+        <form action="/dispatch" method="post" class="{{name}}">
             <input type="hidden" name="method" value="{{method}}">
             <input type="hidden" name="stack" value="{{stack}}">
             


### PR DESCRIPTION
The deploy form class is used to generate the request for stack/env timing information, which is used to generate and animate the deployment status bar.  Without this class, the timing info request 404s.  See ~ line 108 in layout.mustache for the timing info request.
