### PR TITLE
Fix for the <view diff> link in the Stack box(es)

### DIFF
--- a/templates/generic_single_push.mustache
+++ b/templates/generic_single_push.mustache
@@ -18,7 +18,7 @@
             <input type="hidden" name="stack" value="{{stack}}">
             
             <p class="stack-status">
-                <a href="/diff/{{stack}}/{{current_version}}/{{next_build}}" target="_blank">
+                <a href="/diff/{{stack}}/{{current_build}}/{{next_build}}" target="_blank">
                     <span class="{{stack}}_{{name}}_current_build">{{current_build}}</span>
                     &rarr;
                     <span class="{{stack}}_{{name}}_next_build">{{next_build}}</span>


### PR DESCRIPTION
Fixing up compare link on the deploy button to use the **current_build** instead of **current_version**
