### PR TITLE
helpers::use_github fails to detect the existence of the {stack}_git_repo_url function

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -182,7 +182,7 @@ module Deployinator
 
     def use_github(stack, rev1, rev2)
       # Hackery
-      return true if self.respond_to?(stack.to_s + "_git_repo_url")
+      return true if Deployinator::Helpers.respond_to?(stack.to_s + "_git_repo_url")
       return false if [rev1, rev2].all? {|r| r.match(/^\d{5}$/)}
       return true if github_info_for_stack.key?(stack)
       return false


### PR DESCRIPTION
"hack fix" to the use github method of helpers to detect if we are dealing with a git repo based on the existence of the {stack}_git_repo_url method in the stack.

This pull request is an "hack" that fixes the issue - a proper fix would probably require more work and re-thinking on how to access the stack objects instead of checking if the stack_functions are defined.
