### PR TITLE
Update bundler source to use https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem "rake"
 gem "rack", "~> 1.5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     capybara (1.1.4)
       mime-types (>= 1.16)


### PR DESCRIPTION
Related warning when using `source :rubygems` and newer versions of bundler:

<pre>
> bundle install
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
# ...
</pre>
