### PR TITLE
Rename :public to :public_folder because of changes in sinatra

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -10,7 +10,7 @@ module Deployinator
       :namespace => Deployinator
     }
 
-    set :public, "public/"
+    set :public_folder, "public/"
     set :static, true
 
     before do


### PR DESCRIPTION
Sinatra changed from using :public to :public_folder in the following commit. Changing deployinator to match so it works with current versions of Sinatra.
https://github.com/sinatra/sinatra/commit/d1ab58deb380d8b11f5ed7d5317571
4001193a96
