### PR TITLE
stop reopening stdout and stderr

### DIFF
--- a/lib/deployinator/app.rb
+++ b/lib/deployinator/app.rb
@@ -184,8 +184,8 @@ module Deployinator
         Signal.trap("HUP") { exit }
         if Deployinator.log_file?
           log = File.new(Deployinator.log_file, "a")
-          $stdout.reopen(log)
-          $stderr.reopen(log)
+          $stdout.sync = true
+          $stderr.sync = true
           puts "Logging #{Deployinator.log_file}"
         end
         $0 = get_deploy_process_title(params[:stack], params[:stage])

--- a/lib/deployinator/logging.rb
+++ b/lib/deployinator/logging.rb
@@ -1,6 +1,6 @@
 if Deployinator.log_file?
   log = File.new(Deployinator.log_file, "a")
-  $stdout.reopen(log)
-  $stderr.reopen(log)
+  $stdout.sync = true
+  $stderr.sync = true
   puts "Logging #{Deployinator.log_file}"
 end


### PR DESCRIPTION
Some (newer) versions of passenger have startup issues if the app reopens stdout or stderr

Attached patch changes the deployinator logger and app to use sync rather than reopen.
for reference: 
- https://github.com/phusion/passenger/wiki/Debugging-application-startup-problems
- https://github.com/phusion/passenger/issues/1013
- http://stackoverflow.com/a/15350326/973744
- http://stackoverflow.com/questions/6683328/difference-between-reassignment-and-reopen-with-ruby-io-streams

ruby-2.1.2
passenger-4.0.56
