### PR TITLE
Update README.md to work with the gem name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ you can skip the bundler steps.
 
 ```ruby
     source 'https://rubygems.org'
-    gem 'deployinator', :git => 'https://github.com/etsy/deployinator.git', :branch => 'master'
+    gem 'deployinator', :git => 'https://github.com/etsy/deployinator.git', :branch => 'master', :require => 'deployinator'
 ```
 
 - Install all required gems with bundler:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ you can skip the bundler steps.
 
 ```ruby
     source 'https://rubygems.org'
-    gem 'deployinator', :git => 'https://github.com/etsy/deployinator.git', :branch => 'master', :require => 'deployinator'
+    gem 'etsy-deployinator', :git => 'https://github.com/etsy/deployinator.git', :branch => 'master', :require => 'deployinator'
 ```
 
 - Install all required gems with bundler:


### PR DESCRIPTION
This fix an error when running `bundle install` following the instruction:

```
Could not find gem 'deployinator (>= 0) ruby' in https://github.com/etsy/deployinator (at master).
Source does not contain any versions of 'deployinator (>= 0) ruby'
```
