### PR TITLE
Trying to make the run logs easier on the eyes

### DIFF
--- a/lib/deployinator/static/css/style.css
+++ b/lib/deployinator/static/css/style.css
@@ -941,18 +941,28 @@ section#main.config{
 /*consol*/
 .code {
   background-color: #222;
-  color: #ccc;
-  font-family: monospace;
+  color: #ddd;
+  font-size: 16px;
   padding: 8px;
+
 }
 
 .code .command {
+  font-family: monospace;
+  font-size:14px;
+  margin-top:2px;
   border-top: 1px solid #555;
-  padding: 20px 0;
+  padding: 10px 20px 5px 10px;
 }
 .code .command h4 {
-  color: #fff;
+  color: #ccc;
   font-weight: normal;
+}
+
+.code .command h5 {
+    color: #abc;
+    font-size: 12px;
+    margin-bottom:10px;
 }
 .code .command p {
   margin: 10px;


### PR DESCRIPTION
The runlogs are a bit jagged. Here's trying to nudge it in a good direction.
![updated deployoinator runlog style](https://cloud.githubusercontent.com/assets/290200/6521447/05796ada-c3a6-11e4-8eda-5fe02de3a15c.png)
