### PR TITLE
Create helper method: write_to_cache

### DIFF
--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -396,6 +396,20 @@ module Deployinator
       end
     end
 
+    # Public: writes the supplied contents to the cache file, ensuring that
+    # encoding is correct
+    #
+    # Parameters:
+    #    cache_file: path to the cache file
+    #    content: the data to write to the file
+    #
+    # Returns nothing
+    def write_to_cache(cache_file, contents)
+      File.open(cache_file, 'w:UTF-8') do |f|
+        f.write(contents.force_encoding('UTF-8'))
+      end
+    end
+
     def lock_pushes(stack, who, method)
       log_and_stream("LOCKING #{stack}")
       if lock_info = push_lock_info(stack)

--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -369,7 +369,7 @@ module Deployinator
       end
     end
 
-    # Public: gets the contes from a cache file if it hasn't expired
+    # Public: gets the contents from a cache file if it hasn't expired
     #
     # Paramaters:
     #    cache_file: path to a cache file

--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -188,7 +188,7 @@ module Deployinator
 
         unless head_rev
           head_rev = get_git_head_rev(stack, branch)
-          File.open(filename, 'w') {|f| f.write(head_rev) }
+          write_to_cache(filename, head_rev)
         end
 
         return head_rev

--- a/test/unit/git_test.rb
+++ b/test/unit/git_test.rb
@@ -50,4 +50,14 @@ class HelpersTest < Test::Unit::TestCase
     GitHelpers.expects(:log_and_stream).returns(nil)
     GitHelpers.git_freshen_or_clone(:stack, "extra-ssh", "/dev/null", "merge99", false, "https")
   end
+
+  def test_git_head_rev_should_cache_results
+    FileUtils.rm('/tmp/rev_head_cache_some_stack')
+
+    head_rev_sha = 'ba83f60523008e48950f77bd0d3a773f9cb2805c'
+    GitHelpers.expects(:get_git_head_rev).with('some_stack', 'master').returns(head_rev_sha).once
+    assert_equal(head_rev_sha, GitHelpers.git_head_rev('some_stack'))
+    # Calling it a second time should just use the cached result on disk
+    assert_equal(head_rev_sha, GitHelpers.git_head_rev('some_stack'))
+  end
 end

--- a/test/unit/git_test.rb
+++ b/test/unit/git_test.rb
@@ -52,7 +52,7 @@ class HelpersTest < Test::Unit::TestCase
   end
 
   def test_git_head_rev_should_cache_results
-    FileUtils.rm('/tmp/rev_head_cache_some_stack')
+    FileUtils.rm_f('/tmp/rev_head_cache_some_stack')
 
     head_rev_sha = 'ba83f60523008e48950f77bd0d3a773f9cb2805c'
     GitHelpers.expects(:get_git_head_rev).with('some_stack', 'master').returns(head_rev_sha).once

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -15,6 +15,7 @@ class HelpersTest < Test::Unit::TestCase
     @issue2 = "DEF-456"
     @issue1_linked = "#{@jurl % ([@issue1] * 2)}"
     @issue2_linked = "#{@jurl % ([@issue2] * 2)}"
+    @utf8_canary = 'Iñtërnâtiônàlizætiøn'
     Deployinator.default_user = "testuser"
     Deployinator.deploy_host = "deploytest.vm.ny4dev.etsy.com"
     Deployinator.issue_tracker = proc do |issue|
@@ -79,13 +80,12 @@ class HelpersTest < Test::Unit::TestCase
   end
 
   def test_get_from_cache
-    utf8_canary = 'Iñtërnâtiônàlizætiøn'
     Tempfile.open('cache_file', encoding: 'UTF-8') do |tf|
-      tf.write(utf8_canary)
+      tf.write(@utf8_canary)
       tf.flush
 
       cached_content = get_from_cache(tf.path)
-      assert_equal(utf8_canary, cached_content)
+      assert_equal(@utf8_canary, cached_content)
       assert_equal(Encoding.find('UTF-8'), cached_content.encoding)
     end
   end
@@ -103,6 +103,16 @@ class HelpersTest < Test::Unit::TestCase
       assert_equal(false, get_from_cache(tf.path))
       assert_not_equal(false, get_from_cache(tf.path, 30))
       assert_not_equal(false, get_from_cache(tf.path, -1))
+    end
+  end
+
+  def test_write_to_cache
+    Tempfile.open('cache_file') do |tf|
+      write_to_cache(tf.path, @utf8_canary)
+
+      cached_content = get_from_cache(tf.path)
+      assert_equal(@utf8_canary, cached_content)
+      assert_equal(Encoding.find('UTF-8'), cached_content.encoding)
     end
   end
 end


### PR DESCRIPTION
Data that is cached on the file system could include non-ASCII text. The ```get_from_ cache``` method already accounts for the possibility that the system's ```Encoding.default_external``` setting may not be ```UTF-8``` and therefore hardcodes that the files on disk should encode their data in ```UTF-8```. There was not method for writing out those files in a ```UTF-8``` format, so every caching spot needs to include that requirement.

With this PR, there is now a ```write_to_cache``` method that ensures that the data is written out in ```UTF-8```, which ```get_from_cache``` can then read. There was only a single spot in this gem where the cache was used, and that code is updated to use the new ```write_to_cache``` method.

While I was in there, I also added some test coverage around ```get_from_cache``` and fixed a typo in a comment.