### PR TITLE
force checkout in case of local changes

### DIFF
--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -95,7 +95,7 @@ module Deployinator
       # Returns nothing
       def git_freshen_clone(stack, extra_cmd="", path=nil, branch="master")
         path ||= git_checkout_path(checkout_root, stack)
-        cmd = "cd #{path} && git fetch --quiet origin +refs/heads/#{branch}:refs/remotes/origin/#{branch} && git checkout --force #{branch} 2>&1 && git reset --hard origin/#{branch} 2>&1"
+        cmd = "cd #{path} && git fetch --quiet origin +refs/heads/#{branch}:refs/remotes/origin/#{branch} && git checkout #{branch} 2>&1 && git reset --hard origin/#{branch} 2>&1"
         cmd = build_git_cmd(cmd, extra_cmd)
         run_cmd cmd
         yield "#{path}" if block_given?

--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -95,7 +95,7 @@ module Deployinator
       # Returns nothing
       def git_freshen_clone(stack, extra_cmd="", path=nil, branch="master")
         path ||= git_checkout_path(checkout_root, stack)
-        cmd = "cd #{path} && git fetch --quiet origin +refs/heads/#{branch}:refs/remotes/origin/#{branch} && git checkout #{branch} 2>&1 && git reset --hard origin/#{branch} 2>&1"
+        cmd = "cd #{path} && git fetch --quiet origin +refs/heads/#{branch}:refs/remotes/origin/#{branch} && git checkout --force #{branch} 2>&1 && git reset --hard origin/#{branch} 2>&1"
         cmd = build_git_cmd(cmd, extra_cmd)
         run_cmd cmd
         yield "#{path}" if block_given?

--- a/test/unit/git_test.rb
+++ b/test/unit/git_test.rb
@@ -40,10 +40,17 @@ class HelpersTest < Test::Unit::TestCase
     GitHelpers.expects(:git_checkout_path).returns("/dev/null")
     GitHelpers.expects(:is_git_repo).with("/dev/null", "extra-ssh").returns(:true)
     GitHelpers.expects(:log_and_stream).returns(nil)
-    GitHelpers.expects(:git_freshen_clone).with(:stack, "extra-ssh", "/dev/null", "merge99")
+    GitHelpers.expects(:git_freshen_clone).with(:stack, "extra-ssh", "/dev/null", "merge99", false)
     GitHelpers.git_freshen_or_clone(:stack, "extra-ssh", "/dev/null", "merge99", false, "https")
   end
 
+  def test_git_freshen_or_clone_git_update_force
+    GitHelpers.expects(:git_checkout_path).returns("/dev/null")
+    GitHelpers.expects(:is_git_repo).with("/dev/null", "extra-ssh").returns(:true)
+    GitHelpers.expects(:log_and_stream).returns(nil)
+    GitHelpers.expects(:git_freshen_clone).with(:stack, "extra-ssh", "/dev/null", "merge99", true)
+    GitHelpers.git_freshen_or_clone(:stack, "extra-ssh", "/dev/null", "merge99", false, "https", true)
+  end
   def test_git_freshen_or_clone_git_bad_repo
     GitHelpers.expects(:git_checkout_path).returns("/dev/null")
     GitHelpers.expects(:is_git_repo).with("/dev/null", "extra-ssh").returns(:false)


### PR DESCRIPTION
In some cases, local changes subside in the deploy host - the below command fails without the checkout -f

git fetch --quiet origin +refs/heads/master:refs/remotes/origin/master && git checkout master  2>&1 && git reset --hard origin/master 2>&1