### PR TITLE
Defunct processes when deploying from FreeBSD

### DIFF
--- a/lib/deployinator/app.rb
+++ b/lib/deployinator/app.rb
@@ -169,7 +169,7 @@ module Deployinator
         return 403
       end
 
-      fork {
+      pid = fork {
         Signal.trap("HUP") { exit }
         Deployinator.setup_logging
         $0 = get_deploy_process_title(params[:stack], params[:stage])
@@ -177,6 +177,7 @@ module Deployinator
         d = controller.new
         d.run(params)
       }
+      Process.detach(pid)
       200
     end
 


### PR DESCRIPTION
Ruby Version: 2.1.6
Using Unicorn behind Nginx

Detached the forked pid from the parent process