### PR TITLE
remove fixed height from stack list on main page

### DIFF
--- a/lib/deployinator/static/css/style.css
+++ b/lib/deployinator/static/css/style.css
@@ -1156,7 +1156,6 @@ header.web_config {
     margin-top: 20px;
     -webkit-column-width: 220px;
     -moz-column-width: 220px;
-    height: 420px;
 }
 
 .pinned-stack-list { 


### PR DESCRIPTION
A long list of stacks on the main page will overflow the box. This change allows the div height to expand. 