### PR TITLE
change log link on single push page

### DIFF
--- a/lib/deployinator/templates/generic_single_push.mustache
+++ b/lib/deployinator/templates/generic_single_push.mustache
@@ -50,8 +50,9 @@
     <div class="push-topic">
         <div class="title"></div>
         <span class="log-run">
-            <form action="/run_logs">
+            <form action="/log">
                 <button class="button small" type="submit">See run logs</button>
+                <input type="hidden" name="stack" value="{{stack}}" />
             </form>
         </span>
     </div>


### PR DESCRIPTION
The current log link goes to `/run_logs?`, which takes a long time to load. This changes that link to `/log?stack={{stack}}`