### PR TITLE
restore stats dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,30 @@ Next, on every code change, you can install from the checked out gem by running 
     $ bundle install --no-deployment && bundle install --deployment
 ```
 
+### Stats dashboard
+The `/stats` page pulls from `log/deployinator.log` to show a graph of deployments per day for each stack over time. By default, it shows all stacks. To blacklist or whitelist certain stacks, update `config/base.rb` with:
+```rb
+  Deployinator.stats_included_stacks = ['my_whitelisted_stack', 'another_whitelisted_stack']
+  Deployinator.stats_ignored_stacks = ['my_stack_to_ignore', 'another_stack_to_ignore']
+  Deployinator.stats_extra_grep = 'Production deploy' # filter out log entries matching this string 
+```
+
+Whitelisting stacks or applying a custom extra grep can help speed up graph rendering when you have a large log file. 
+
+If at some point you change the name of a stack, you can group the old log entries with the new by adding the following to `config/base.rb`:
+
+```rb
+ Deployinator.stats_renamed_stacks = [
+   {
+     :previous_stack => {
+       :stack => [ "old_stack_name" ]
+     },
+     :new_name => "new_stack_name"
+   }
+ ]
+```
+
+
 ### Contributing
 
 1. Fork it

--- a/lib/deployinator.rb
+++ b/lib/deployinator.rb
@@ -64,9 +64,10 @@ module Deployinator
     # exclude stacks in /stats, even if present in stats_included_stacks
     attr_accessor :stats_ignored_stacks
 
-    # log entries must contain this to appear in /stats
+    # filter log entries in /stats
     attr_accessor :stats_extra_grep
 
+    # list of configurations for grouping historical / renamed stacks in /stats
     attr_accessor :stats_renamed_stacks
     @@stats_renamed_stacks = []
 

--- a/lib/deployinator.rb
+++ b/lib/deployinator.rb
@@ -67,6 +67,8 @@ module Deployinator
     # log entries must contain this to appear in /stats
     attr_accessor :stats_extra_grep
 
+    attr_accessor :stats_renamed_stacks
+    @@stats_renamed_stacks = []
 
     def initialize
       @stack_plugins = {}

--- a/lib/deployinator.rb
+++ b/lib/deployinator.rb
@@ -58,6 +58,16 @@ module Deployinator
     # if you override this it should be a subclass of Deployinator::Controller
     attr_accessor :deploy_controller
 
+    # include stacks in /stats
+    attr_accessor :stats_included_stacks
+
+    # exclude stacks in /stats, even if present in stats_included_stacks
+    attr_accessor :stats_ignored_stacks
+
+    # log entries must contain this to appear in /stats
+    attr_accessor :stats_extra_grep
+
+
     def initialize
       @stack_plugins = {}
       @global_plugins = []

--- a/lib/deployinator/app.rb
+++ b/lib/deployinator/app.rb
@@ -143,6 +143,10 @@ module Deployinator
       send_file "#{File.dirname(__FILE__)}/static/js/jquery.timed_bar.js"
     end
 
+    get '/js/stats_load.js' do
+      send_file "#{File.dirname(__FILE__)}/static/js/stats_load.js"
+    end
+
     get '/deploys_status' do
         mustache Deployinator::Views::DeploysStatus
     end

--- a/lib/deployinator/app.rb
+++ b/lib/deployinator/app.rb
@@ -12,6 +12,7 @@ require 'deployinator/views/log'
 require 'deployinator/views/run_logs'
 require 'deployinator/views/log_table'
 require 'deployinator/views/deploys_status'
+require 'deployinator/views/stats'
 
 module Deployinator
   class DeployinatorApp < Sinatra::Base
@@ -45,6 +46,10 @@ module Deployinator
 
     get '/' do
         mustache Deployinator::Views::Index
+    end
+
+    get '/stats' do
+        mustache Deployinator::Views::Stats
     end
 
     get '/run_logs/view/:log' do

--- a/lib/deployinator/static/js/stats_load.js
+++ b/lib/deployinator/static/js/stats_load.js
@@ -1,0 +1,10 @@
+$(function() {
+    $.each(data, function(key, val) {
+        $("#choices").append('<h3><input type="checkbox" name="' + key +
+           '" checked="checked" id="id' + key + '">' +
+           '<label for="id' + key + '">'+ val.label + '</label></h3>');
+    });
+    
+    $("#choices").find("input").click(drawGraphs);
+    drawGraphs();
+})

--- a/lib/deployinator/templates/stats.mustache
+++ b/lib/deployinator/templates/stats.mustache
@@ -1,0 +1,180 @@
+<!-- content -->
+<section id="main" class="info stats">
+    <!-- heading -->
+    <div class="heading clearfix">
+        <h2>Deployments Per Day (US/Eastern)</h2>
+    </div>
+    <div class="stats-main">
+        <button id="scatterOrLine">Line</button>
+        <label><input type="checkbox" id="combined"> Combined</label>
+        <div id="placeholder" style="width:940px;height:300px;"></div>
+        <div id="overview" style="width:940px;height:120px;"></div>
+        <script>var data = {}</script>
+
+        <p id="choices"></p>
+
+        <div class="holder">
+
+            {{# per_day}}
+            <div class="stats">
+                <table class="stats">
+                    <tr>
+                        <th>Day</th>
+                        <th>Count</th>
+                    </tr>
+                    {{# data}}
+                    <tr>
+                        <td>{{date}}</td>
+                        <td class="count">{{count}}</td>
+                    </tr>
+                    {{/ data}}
+                </table>
+                <h3>{{stack}}</h3>
+                <script type="text/javascript" charset="utf-8">
+                    data["{{stack}}"] = {data: {{json}}, label: "{{stack}}"}
+                </script>
+            </div>
+            {{/ per_day}}
+
+        </div>
+    </div>
+    
+</section>
+
+<script type="text/javascript" charset="utf-8">
+    var x1, x2;
+
+    function getData(ignoreX) {
+        var d = [];
+        var c = { data: [], label: "combined" };
+
+        $("#choices").find("input:checked").each(function() {
+            if ($(this).attr("id") == "combined") { return; }
+
+            var key = $(this).attr("name");
+
+            if (key && data[key]) {
+                // combine all the data points if requested
+                if ($("#combined")[0].checked) {
+                    for (var i=0; i<data[key].data.length; i++) {
+                        var found = false;
+                        var m = data[key].data[i];
+                        for (var j=0; j<c.data.length; j++) {
+                            var n = c.data[j];
+                            if (n[0] == m[0]) {
+                                n[1] += m[1];
+                                found = true;
+                                break;
+                            }
+                        }
+
+                        if (! found) { c.data[i] = [m[0], m[1]]; }
+                    }
+                }
+
+                d.push(data[key]);
+            }
+        });
+
+        if ($("#combined")[0].checked) { d = [c]; }
+
+        var newD = [];
+        for (var i=0; i<d.length; i++) {
+            var dAr = [];
+            for (var j=0; j<d[i].data.length; j++) {
+                n = d[i].data[j];
+                dAr.push(n);
+            }
+            newD[i] = { label: d[i].label, data: dAr };
+        }
+
+        if ($("#combined")[0].checked) { outputTable(c); }
+        return newD;
+    }
+
+    function outputTable(c) {
+        $("#holderCombined").remove();
+
+        var table = $("<table id='holderCombined'>")
+          .html("<tr><th>Date</th><th>Combined</th></tr>")
+          .appendTo(".stats-main");
+
+        for (var i=0; i<c.data.length; i++) {
+            var m = c.data[i];
+            var dO = new Date(m[0]);
+            var dateS = (dO.getYear() + 1900) + "-" + dO.getMonth() + "-" + dO.getDate();
+            $("<tr><td>" + dateS + "</td><td>" + m[1] + "</td></tr>")
+              .appendTo(table);
+        }
+    }
+
+    function options() {
+        return {
+            xaxis: { mode: "time", timeformat: "%y/%m/%d", minTickSize: [1, "day"] },
+            legend: { position: "nw" },
+            points: { show: ($("#scatterOrLine").html() == "Scatter") },
+            lines: { show: ($("#scatterOrLine").html() == "Line") },
+            selection: { mode: "x" }
+        }
+    };
+
+    function sliceD(d, msg) {
+        return d.slice(d.slice(d.indexOf(x1), d.indexOf(x2)));
+    }
+
+    function drawGraphs() {
+        var d = getData();
+
+        var plot = $.plot($("#placeholder"), sliceD(d, "main"), options());
+
+        var overview = $.plot($("#overview"), d, {
+            legend: { show: false },
+            selection: { mode: "x" },
+            lines: { show: true },
+            xaxis: { mode: "time", timeformat: "%y/%m/%d" }
+        });
+
+        $("#placeholder").unbind("plotselected");
+        $("#placeholder").bind("plotselected", function (event, cRanges) {
+            ranges = cRanges;
+            x1 = Math.floor(ranges.xaxis.from);
+            x2 = Math.floor(ranges.xaxis.to);
+
+            // do the zooming
+            plot = $.plot($("#placeholder"), sliceD(d, "zoom"),
+                $.extend(true, {}, options(), {
+                    xaxis: { min: ranges.xaxis.from, max: ranges.xaxis.to },
+                    yaxis: { min: ranges.yaxis.from, max: ranges.yaxis.to }
+            }));
+
+            // don't fire event on the overview to prevent eternal loop
+            overview.setSelection(ranges, true);
+        });
+
+        $("#overview").unbind("plotselected");
+        $("#overview").bind("plotselected", function (event, ranges) {
+            plot.setSelection(ranges);
+
+            x1 = Math.floor(ranges.xaxis.from);
+            x2 = Math.floor(ranges.xaxis.to);
+        });
+
+        if (x1 && x2) {
+            ranges = {xaxis: {from: x1, to: x2}};
+
+            overview.setSelection(ranges);
+            plot.setSelection(ranges);
+        }
+    }
+
+    $("#scatterOrLine").live("click", function () {
+        $(this).html(($(this).html() == "Line") ? "Scatter" : "Line");
+
+        drawGraphs();
+    });
+
+    $("#combined").live("click", function () {
+        drawGraphs();
+    });
+</script>
+<script src="/js/stats_load.js"></script>

--- a/lib/deployinator/views/stats.rb
+++ b/lib/deployinator/views/stats.rb
@@ -28,16 +28,16 @@ module Deployinator::Views
 
     def inject_renamed_stacks(renamed_stacks)
       return if nil == renamed_stacks
-      
+
       renamed_stacks.each do |ops|
         previous_stack = ops[:previous_stack]
-        new_name = ops[:new_name]
+        new_stack_name = ops[:new_name]
 
         renamed_stack_data = log_to_hash(previous_stack)
 
-        renamed_stack_data.inject({}) do |h, cfg|
-          cfg[:stack] = new_name
-          deploys.push(cfg)
+        renamed_stack_data.each do |data|
+          data[:stack] = new_stack_name
+          deploys.push(data)
         end
       end
     end

--- a/lib/deployinator/views/stats.rb
+++ b/lib/deployinator/views/stats.rb
@@ -1,0 +1,101 @@
+require 'json'
+require 'time'
+require './views/etsy-layout'
+
+module Deployinator::Views
+  class Stats < EtsyLayout
+
+    @@get_these_stacks = ['web', 'photos', 'blog', 'search', 'xsearch', 'supergrep', 'graphite' ]
+    @@ignore_these_stacks = ['webs','LOG MESSAGE', 'deploy', 'api', 'imagestorage' , 'storque', 'atlas' ]
+
+    def deploys
+      @deploys ||= begin
+        log_to_hash({
+          :no_global => false,
+          :stack => @@get_these_stacks,
+          :env => "production|search|prod",
+          :extragrep => "Production deploy",
+          :no_limit => true,
+          :limit => 10000
+        })
+       end
+        # note that the stack param will help but will send bring back extra lines that matched
+    end
+
+    def configs
+      # around the start of 2012 config became its own stack (web_config)
+      # we when looking for config deploys we want to check old (web) and new
+      # (web_config) for charting. MAYHEM-357
+       @configs ||= begin
+        log_to_hash({
+          :env => "config",
+          :extragrep => "CONFIG PRODUCTION Deploy",
+          :no_limit => false,
+          :limit => 10000,
+          :no_global => true,
+          :stack => [ "web" , "web_config" ]
+        })
+      end
+    end
+
+    def timings
+      deploys
+    end
+
+    def per_day
+      # smush the config array into the deploy array
+      # and goose the stack to appear as a config stack
+      foo = configs.inject({}) do |h, cfg|
+        cfg[:stack] = cfg[:env].downcase
+        deploys.push(cfg)
+      end
+
+      original_zone = ENV["TZ"]
+      ENV["TZ"] = "US/Eastern"
+
+      early_day = Time.now.strftime("%Y-%m-%d")
+      stack_days = deploys.inject({}) do |h, deploy|
+        if deploy[:time] && deploy[:stack]
+          if @@ignore_these_stacks.include?(deploy[:stack])
+            # puts "SKIPPING " + deploy[:stack]
+            # something breaks if you just next here so don't
+          else
+            day = Date.parse(deploy[:time].localtime.strftime("%Y-%m-%d"))
+            early_day = day if day.to_s < early_day.to_s
+            h[deploy[:stack]] ||= {}
+            h[deploy[:stack]][day] ||= 0
+            h[deploy[:stack]][day] += 1
+          end
+        end
+        h
+      end
+
+      # fill in zero days
+      day_seconds = 24 * 60 * 60
+      (0..((Time.now - Time.parse(early_day.to_s)) / day_seconds).to_i).each do |days_ago|
+        stack_days.keys.each do |stack|
+
+          next if @@ignore_these_stacks.include?(stack)
+          day = Date.parse((Time.now - (day_seconds * days_ago)).strftime("%Y-%m-%d"))
+          stack_days[stack][day] ||= 0
+        end
+      end
+
+      n = stack_days.keys.map do |stack|
+        next if @@ignore_these_stacks.include?(stack)
+
+        data = []
+        json = []
+        stack_days[stack].sort.reverse.each do |d,c|
+          data << {:date => d, :count => c}
+          json << [d.strftime("%s").to_i * 1000, c]
+        end
+        {:stack => stack, :data => data, :json => json.to_json}
+      end
+
+      ENV["TZ"] = original_zone
+
+      n
+    end
+  end
+end

--- a/lib/deployinator/views/stats.rb
+++ b/lib/deployinator/views/stats.rb
@@ -6,16 +6,15 @@ module Deployinator::Views
 
     self.template_file = "#{File.dirname(__FILE__)}/../templates/stats.mustache"
 
-    @@get_these_stacks = ['web', 'photos', 'blog', 'search', 'xsearch', 'supergrep', 'graphite' ]
-    @@ignore_these_stacks = ['webs','LOG MESSAGE', 'deploy', 'api', 'imagestorage' , 'storque', 'atlas' ]
+    @@ignored_stacks = Deployinator.stats_ignored_stacks
 
     def deploys
       @deploys ||= begin
         log_to_hash({
           :no_global => false,
-          :stack => @@get_these_stacks,
+          :stack => Deployinator.stats_included_stacks,
           :env => "production|search|prod",
-          :extragrep => "Production deploy",
+          :extragrep => Deployinator.stats_extra_grep,
           :no_limit => true,
           :limit => 10000
         })
@@ -23,41 +22,18 @@ module Deployinator::Views
         # note that the stack param will help but will send bring back extra lines that matched
     end
 
-    def configs
-      # around the start of 2012 config became its own stack (web_config)
-      # we when looking for config deploys we want to check old (web) and new
-      # (web_config) for charting. MAYHEM-357
-       @configs ||= begin
-        log_to_hash({
-          :env => "config",
-          :extragrep => "CONFIG PRODUCTION Deploy",
-          :no_limit => false,
-          :limit => 10000,
-          :no_global => true,
-          :stack => [ "web" , "web_config" ]
-        })
-      end
-    end
-
     def timings
       deploys
     end
 
     def per_day
-      # smush the config array into the deploy array
-      # and goose the stack to appear as a config stack
-      foo = configs.inject({}) do |h, cfg|
-        cfg[:stack] = cfg[:env].downcase
-        deploys.push(cfg)
-      end
-
       original_zone = ENV["TZ"]
       ENV["TZ"] = "US/Eastern"
 
       early_day = Time.now.strftime("%Y-%m-%d")
       stack_days = deploys.inject({}) do |h, deploy|
         if deploy[:time] && deploy[:stack]
-          if @@ignore_these_stacks.include?(deploy[:stack])
+          if @@ignored_stacks.include?(deploy[:stack])
             # puts "SKIPPING " + deploy[:stack]
             # something breaks if you just next here so don't
           else
@@ -76,14 +52,14 @@ module Deployinator::Views
       (0..((Time.now - Time.parse(early_day.to_s)) / day_seconds).to_i).each do |days_ago|
         stack_days.keys.each do |stack|
 
-          next if @@ignore_these_stacks.include?(stack)
+          next if @@ignored_stacks.include?(stack)
           day = Date.parse((Time.now - (day_seconds * days_ago)).strftime("%Y-%m-%d"))
           stack_days[stack][day] ||= 0
         end
       end
 
       n = stack_days.keys.map do |stack|
-        next if @@ignore_these_stacks.include?(stack)
+        next if @@ignored_stacks.include?(stack)
 
         data = []
         json = []

--- a/lib/deployinator/views/stats.rb
+++ b/lib/deployinator/views/stats.rb
@@ -1,9 +1,10 @@
 require 'json'
 require 'time'
-require './views/etsy-layout'
 
 module Deployinator::Views
-  class Stats < EtsyLayout
+  class Stats < Layout
+
+    self.template_file = "#{File.dirname(__FILE__)}/../templates/stats.mustache"
 
     @@get_these_stacks = ['web', 'photos', 'blog', 'search', 'xsearch', 'supergrep', 'graphite' ]
     @@ignore_these_stacks = ['webs','LOG MESSAGE', 'deploy', 'api', 'imagestorage' , 'storque', 'atlas' ]


### PR DESCRIPTION
The stats dashboard was lost in the ruby gem migration. This PR brings in code from the last time it was set up: https://github.etsycorp.com/Engineering/DeployinatorStacks/tree/web_rewrite