### PR TITLE
update logging of exceptions to be prettier and more usuable

### DIFF
--- a/lib/deployinator/templates/exception.mustache
+++ b/lib/deployinator/templates/exception.mustache
@@ -1,0 +1,11 @@
+<div>
+  <code>
+    {{#exceptions}}
+    <div style='white-space: nowrap;'>
+      <span>{{file}}</span>
+      <span>+{{line}}</span>
+      <span>({{method}})</span>
+    </div>
+    {{/exceptions}}
+  </code>
+</div>


### PR DESCRIPTION
currently, if an exception is thrown and the `log_error` method is called, the backtrace is logged without any formatting. This makes it super difficult to look at and view, and requires reformatting when copying and pasting.

This PR represents a change to that, so that the backtrace is rendered as HTML.