### PR TITLE
Fix next previous page logs

### DIFF
--- a/lib/deployinator/templates/log_table.mustache
+++ b/lib/deployinator/templates/log_table.mustache
@@ -67,7 +67,9 @@
             <th>
                 {{# prev_page }}
                 <form action="/log">
-                    <input type="hidden" name="page" value="{{prev_page}}" />
+                    {{#prev_page_params}}
+                    <input type="hidden" name="{{name}}" value="{{value}}" />
+                    {{/prev_page_params}}
                     <button class="button small">Prev</button>
                 </form>
                 {{/ prev_page }}
@@ -79,7 +81,9 @@
             <th></th>
             <th>
                 <form action="/log">
-                    <input type="hidden" name="page" value="{{next_page}}" />
+                    {{#next_page_params}}
+                    <input type="hidden" name="{{name}}" value="{{value}}" />
+                    {{/next_page_params}}
                     <button class="button small">Next</button>
                 </form>
 

--- a/lib/deployinator/templates/log_table.mustache
+++ b/lib/deployinator/templates/log_table.mustache
@@ -3,7 +3,12 @@
         <tr>
             <th>
                 {{# prev_page }}
-                  <a href="?page={{prev_page}}">prev</a>
+                <form action="/log">
+                    {{#prev_page_params}}
+                    <input type="hidden" name="{{name}}" value="{{value}}" />
+                    {{/prev_page_params}}
+                    <button class="button small">Prev</button>
+                </form>
                 {{/ prev_page }}
             </th>
             <th></th>
@@ -11,9 +16,13 @@
             <th></th>
             <th></th>
             <th></th>
-            <th></th>
             <th>
-                <a href="?page={{next_page}}">next</a>
+                <form action="/log">
+                    {{#next_page_params}}
+                    <input type="hidden" name="{{name}}" value="{{value}}" />
+                    {{/next_page_params}}
+                    <button class="button small">Next</button>
+                </form>
             </th>
         </tr>
         <tr>

--- a/lib/deployinator/views/log_table.rb
+++ b/lib/deployinator/views/log_table.rb
@@ -17,6 +17,42 @@ module Deployinator::Views
       @params[:show_counts] == "true"
     end
 
+    def next_page_params
+      params = [
+        {
+          :name  => "page",
+          :value => next_page
+        }
+      ]
+
+      unless @params[:stack].nil?
+        params << {
+          :name   => "stack",
+          :value  => @params[:stack]
+        }
+      end
+
+      return params
+    end
+
+    def prev_page_params
+      params = [
+        {
+          :name  => "page",
+          :value => prev_page
+        }
+      ]
+
+      unless @params[:stack].nil?
+        params << {
+          :name   => "stack",
+          :value  => @params[:stack]
+        }
+      end
+
+      return params
+    end
+
     def prev_page
       return unless @params && @params[:page]
       page = @params[:page].to_i


### PR DESCRIPTION
Currently, if you specify the stack param when viewing /logs, the next / prev buttons link to a page that doesn't include that stack value. This PR fixes that (and also updates the buttons at the top to match those at that bottom)