### PR TITLE
replacing /s regex modifier with /m

### DIFF
--- a/lib/deployinator/controller.rb
+++ b/lib/deployinator/controller.rb
@@ -38,7 +38,7 @@ module Deployinator
 
       # This gets the runlog output on the console; is used by log_and_stream
       @block = args[:block] || Proc.new do |output|
-        $stdout.write output.gsub!(/(<[^>]*>)|\n|\t/s) {" "}
+        $stdout.write output.gsub!(/(<[^>]*>)|\n|\t/m) {" "}
         $stdout.write "\n"
       end
     end


### PR DESCRIPTION
Unlike Perl and PHP, the `/s` is for setting the encoding to SJIS in Ruby. Presumably what is desired here was the `/m` modifier to make dot (`.`) match newlines.

Having the /s regex modifier was causing this error with `ruby 1.9.3p547 (2014-05-14 revision 45962) [x86_64-linux]`:

    (incompatible encoding regexp match (Windows-31J regexp with UTF-8 string))

See: [http://www.zenspider.com/Languages/Ruby/QuickRef.html#11] [http://php.net/manual/en/reference.pcre.pattern.modifiers.php]

@jayson
