### PR TITLE
Fix stack Drop-down when "Choose..." gets clicked.

### DIFF
--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -53,7 +53,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                        <span class="label">Stack: </span>
                        <span>
                            <select name='stacks' id='stacks'>
-                           <option>Choose...</option>
+                           <option value="">Choose...</option>
                            {{#get_stack_select}}
                            <option value="{{stack}}"{{#current}} selected{{/current}}>{{stack}}</option>
                            {{/get_stack_select}}

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -53,7 +53,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                        <span class="label">Stack: </span>
                        <span>
                            <select name='stacks' id='stacks'>
-                           <option value="" disabled>Choose...</option>
+                           <option value="">Choose...</option>
                            {{#get_stack_select}}
                            <option value="{{stack}}"{{#current}} selected{{/current}}>{{stack}}</option>
                            {{/get_stack_select}}

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -53,7 +53,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                        <span class="label">Stack: </span>
                        <span>
                            <select name='stacks' id='stacks'>
-                           <option value="">Choose...</option>
+                           <option value="" disabled>Choose...</option>
                            {{#get_stack_select}}
                            <option value="{{stack}}"{{#current}} selected{{/current}}>{{stack}}</option>
                            {{/get_stack_select}}


### PR DESCRIPTION
A quick fix to prevent deployinator throwing a nasty exception if the user clicks "Choose..." in the stack drop down. 

To prevent this, I have disabled the default "Choose" option in the dropdown.

I was going to return to the index on selection however, it's probably better to just disable it from being selected.

Thanks!