### PR TITLE
Redirect to index on user clicking "Choose..."

### DIFF
--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -53,7 +53,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                        <span class="label">Stack: </span>
                        <span>
                            <select name='stacks' id='stacks'>
-                           <option>Choose...</option>
+                           <option value="">Choose...</option>
                            {{#get_stack_select}}
                            <option value="{{stack}}"{{#current}} selected{{/current}}>{{stack}}</option>
                            {{/get_stack_select}}


### PR DESCRIPTION
Hey Guys,

If you click "Choose..." (because of stupidity or caffeine twitches) on the stacks dropdown, you get a nice stacktrace. 

IMO it's more graceful / user friendly to redirect to the index.

This PR sorts that out.

Thanks, Tim.