### PR TITLE
Only show runlogs for the correct stack

### DIFF
--- a/deployinator.gemspec
+++ b/deployinator.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rake", "~> 10", ">= 10.3.2"
   gem.add_runtime_dependency "json", "~> 1.8"
   gem.add_runtime_dependency "mustache", "~> 0.99"
+  # pony pulls in mail >2.0. mail 3.0 needs ruby 2 or greater. to maintain ruby 1.9 compat we're pinning mail here
+  gem.add_runtime_dependency "mail", "2.6.3"
   gem.add_runtime_dependency "pony", "~> 1.5"
   gem.add_runtime_dependency "tlsmail", "~> 0.0"
   gem.add_runtime_dependency "eventmachine", "~> 1.0", ">= 1.0.4"

--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -602,7 +602,7 @@ module Deployinator
       # stack should be the last part of the log line from the last pipe to the end
       # modified this to take into account the run_log entry at the end
       unless stacks.empty? && env.empty?
-        grep = "| egrep '#{env}.*\\|\(#{stacks.join("|")}\)(|(\\||$))?'"
+        grep = "| egrep '#{env}.*\\|\(#{stacks.join("|")}\)\\|'"
       end
 
       # extra grep does another filter to the line, needed to get CONFIG PRODUCTION


### PR DESCRIPTION
The method for matching runlogs to stacks would show logs from all stacks that
started with the same name as the current stack - for instance, the web stack
would also show runlogs from web_config.
This change addresses that.