### PR TITLE
fix the circular reference error

### DIFF
--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -226,8 +226,8 @@ module Deployinator
       # branch        - Git branch to checkout. Defaults to 'master'.
       #
       # Returns nothing
-      def git_clone(stack, repo_url, extra_cmd="", checkout_root=checkout_root, branch='master')
-        path =  git_checkout_path(checkout_root, stack)
+      def git_clone(stack, repo_url, extra_cmd="", local_checkout_root=checkout_root, branch='master')
+        path =  git_checkout_path(local_checkout_root, stack)
         cmd = "git clone #{repo_url} -b #{branch} #{path}"
         cmd = build_git_cmd(cmd, extra_cmd)
         run_cmd cmd


### PR DESCRIPTION
this fixes the repeated error `/path/to/vendor/bundle/ruby/2.2.0/gems/etsy-deployinator-1.1.1/lib/deployinator/helpers/git.rb:229: warning: circular argument reference - checkout_root