### PR TITLE
add an config param to override the git protocol

### DIFF
--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -246,9 +246,12 @@ module Deployinator
       def git_url(stack, protocol="git", read_write=false)
         stack = stack.intern
         repo = git_info_for_stack[stack][:repository]
+        git_protocol = git_info_for_stack[stack][:git_protocol] || nil
         github_host = which_github_host(stack)
         repo += ".git" if protocol != "git"
-        if (read_write)
+        if (!git_protocol.nil?)
+          return "#{git_protocol}#{github_host}:#{git_info_for_stack[stack][:user]}/#{repo}"
+        elsif (read_write)
           return "git@#{github_host}:#{git_info_for_stack[stack][:user]}/#{repo}"
         else
           return "#{protocol}://#{github_host}/#{git_info_for_stack[stack][:user]}/#{repo}"

--- a/test/unit/git_test.rb
+++ b/test/unit/git_test.rb
@@ -8,25 +8,19 @@ class HelpersTest < Test::Unit::TestCase
 
   def test_git_url_https
     GitHelpers.expects(:which_github_host).returns("www.testmagic.com")
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
+    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}}).at_least_once
     assert_equal('https://www.testmagic.com/construction/drills.git', GitHelpers.git_url(:stack, 'https', false))
   end
 
   def test_git_url_default
     GitHelpers.expects(:which_github_host).returns("www.testmagic.com")
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
+    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}}).at_least_once
     assert_equal('git://www.testmagic.com/construction/drills', GitHelpers.git_url(:stack))
   end
 
   def test_git_url_read_write
     GitHelpers.expects(:which_github_host).returns("www.testmagic.com")
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
-    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
+    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}}).at_least_once
     assert_equal('git@www.testmagic.com:construction/drills', GitHelpers.git_url(:stack, "git", true))
   end
 

--- a/test/unit/git_test.rb
+++ b/test/unit/git_test.rb
@@ -10,6 +10,7 @@ class HelpersTest < Test::Unit::TestCase
     GitHelpers.expects(:which_github_host).returns("www.testmagic.com")
     GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
+    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     assert_equal('https://www.testmagic.com/construction/drills.git', GitHelpers.git_url(:stack, 'https', false))
   end
 
@@ -17,11 +18,13 @@ class HelpersTest < Test::Unit::TestCase
     GitHelpers.expects(:which_github_host).returns("www.testmagic.com")
     GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
+    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     assert_equal('git://www.testmagic.com/construction/drills', GitHelpers.git_url(:stack))
   end
 
   def test_git_url_read_write
     GitHelpers.expects(:which_github_host).returns("www.testmagic.com")
+    GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     GitHelpers.expects(:git_info_for_stack).returns({:stack => {:repository => 'drills', :user => 'construction'}})
     assert_equal('git@www.testmagic.com:construction/drills', GitHelpers.git_url(:stack, "git", true))


### PR DESCRIPTION
the read_write param isn't passed consistently to `git_url`, and there are some places where it may even be hard to pass (such as `get '/head_rev/:stack'`)  

this patch is backward compatible with the current functionality but gives the user the ability to add a stack config option such as `:git_protocol => "git@",` which will overwrite the default of `git://` 

This allows deployinator to work with private repositories without changing all the invocations of `git_url`, `get_git_head_rev` and `git_head_rev` and wherever else it may be called from