### PR TITLE
[run_cmd] escape html entities in log_and_stream output for run_cmd

### DIFF
--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -1,5 +1,6 @@
 require 'benchmark'
 require 'timeout'
+require 'cgi'
 require 'deployinator/helpers/version'
 require 'deployinator/helpers/plugin'
 
@@ -158,12 +159,12 @@ module Deployinator
             output << chr
             ret << chr
             if chr == "\n" || chr == "\r"
-              log_and_stream output + "<br>"
+              log_and_stream CGI::escapeHTML(output) + "<br>"
               output = ""
             end
           end
           error_message = nil
-          log_and_stream(output) unless output.empty?
+          log_and_stream(CGI::escapeHTML(output)) unless output.empty?
 
           error_message = err.read unless err.eof?
           if (log_errors) then


### PR DESCRIPTION
The output of some commands actually yields semi-valid html. Because `log_and_stream` outputs this raw, it makes it possible that some command output gets rendered as HTML, which can hide useful logging information.

(a good example of what this might hide is if a command interacts with an API and receives an XML response which is output — the browser would hide this response because it might render as valid / invalid html)