### PR TITLE
change pgrep command in is_deploy_active

### DIFF
--- a/lib/deployinator/helpers/deploy.rb
+++ b/lib/deployinator/helpers/deploy.rb
@@ -45,7 +45,7 @@ module Deployinator
         # is not running
         def is_deploy_active?(stack, stage)
           if deployname = get_deploy_process_title(stack,stage)
-            return system("pgrep -f '#{deployname}'")
+            return system("pgrep -c '#{deployname}'")
           end
           false
         end


### PR DESCRIPTION
this will now
 - only look at the process name
 - only check the count of matches (not totally necessary but cleaner)