### PR TITLE
adding support for secure websocket proxy

### DIFF
--- a/lib/deployinator.rb
+++ b/lib/deployinator.rb
@@ -51,6 +51,8 @@ module Deployinator
 
     attr_accessor :stack_tailer_port
 
+    attr_accessor :stack_tailer_websocket_port
+
     attr_accessor :admin_groups
     @admin_groups = []
 
@@ -134,7 +136,8 @@ Deployinator.log_path = Deployinator.root(["log", "deployinator.log"])
 Deployinator.timing_log_path = Deployinator.root(["log", "deployinator-timing.log"])
 Deployinator.git_sha_length = "10"
 Deployinator.default_user = `/usr/bin/whoami`
-Deployinator.stack_tailer_port = 7778
+Deployinator.stack_tailer_port = 7778 # backend port, tailer listens here
+Deployinator.stack_tailer_websocket_port = 7778 # frontend port, proxy listens here
 Deployinator.github_host = 'github.com'
 Deployinator.app_context['context'] = 'dev'
 

--- a/lib/deployinator/helpers/stack-tail.rb
+++ b/lib/deployinator/helpers/stack-tail.rb
@@ -25,7 +25,7 @@ module Deployinator
 
       # Returns the websocket port for the stack tailer
       def stack_tail_websocket_port
-        Deployinator.stack_tailer_port
+        Deployinator.stack_tailer_websocket_port
       end
     end
   end

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -133,7 +133,8 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                 function connect_web_socket(stack, rnd_id, bar, button) {
                   var bufferedMsg = '';
                   var append;
-                  var ws = new WebSocket('ws://' + window.location.hostname + ':{{stack_tail_websocket_port}}');
+                  var ws_scheme = (location.protocol === 'http:') ? 'ws:' : 'wss:';
+                  var ws = new WebSocket(ws_scheme + '//' + window.location.hostname + ':{{stack_tail_websocket_port}}');
                   var show = function(el) {
                     return function(msg) {
                       bufferedMsg = bufferedMsg + msg;


### PR DESCRIPTION
adds the ability to:
    - differentiate between a frontend/backend port (for proxy setups that may listen on another port)
    - ensure we are using wss: protocol instead of ws: if the scheme is https: