### PR TITLE
add staging to method regex

### DIFF
--- a/lib/deployinator/controller.rb
+++ b/lib/deployinator/controller.rb
@@ -137,7 +137,7 @@ module Deployinator
       elsif options[:method].match(/force_builda/)
         env = "force asset rebuild"
       else
-        env = options[:method][/(dev|qa|production|princess|prod|webs|stage|config)/i, 1] || "other"
+        env = options[:method][/(dev|qa|production|princess|prod|webs|stage|staging|config)/i, 1] || "other"
         env = "production" if env.match(/prod|webs/)
       end
 


### PR DESCRIPTION
my method is `web_staging` so I had to force `options[:method] = 'stage'` to get the message to show something that isn't `OTHER deploy in web stack complete` - adding `staging` to the regex here fixes for my case, but there is probably a less brittle way to handle this overall