### PR TITLE
Add invisible_stacks attribute and make some things safer

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ modify the gem code. Here is a list of current pluggable events:
 - __:logout_url__ for defining your own authentications logout url
 - __:deploy_start__ for any actions to be performed at the start of a deploy
 - __:deploy_end__ for any actions to be performed at the end of a deploy
+- __:log_file_retired__ for when the symlink for the current log is retired
 - __:deploy_error__ for any actions to be performed when an error occurs during a
 deploy
 - __:run_command_start__ for any actions to be performed at the start of a run_cmd

--- a/bin/deployinator-tailer.rb
+++ b/bin/deployinator-tailer.rb
@@ -16,7 +16,7 @@ EM.run do
   # reload the list of stacks from Deployinator without affecting
   # existing channels. does not remove stacks that no longer exist`
   def refresh_stacks
-    Deployinator.get_stacks.each do |stack|
+    Deployinator.get_visible_stacks.each do |stack|
       unless @@channels.key?(stack)
         @@channels[stack] = EM::Channel.new
         @@channels_count[stack] = 0

--- a/lib/deployinator.rb
+++ b/lib/deployinator.rb
@@ -81,6 +81,8 @@ module Deployinator
     attr_accessor :stats_renamed_stacks
     @@stats_renamed_stacks = []
 
+    attr_accessor :invisible_stacks
+
     def initialize
       @stack_plugins = {}
       @global_plugins = []
@@ -126,6 +128,13 @@ module Deployinator
         File.basename(file, ".rb")
       end
     end
+
+    def get_visible_stacks
+      invisible = self.invisible_stacks.map(&:to_s)
+
+      # array subtraction
+      self.get_stacks - invisible
+    end
   end
 end
 
@@ -145,5 +154,6 @@ Deployinator.stack_tailer_websocket_port = 7778 # frontend port, proxy listens h
 Deployinator.github_host = 'github.com'
 Deployinator.index_view_class = Deployinator::Views::Index
 Deployinator.app_context['context'] = 'dev'
+Deployinator.invisible_stacks = []
 
 

--- a/lib/deployinator/app.rb
+++ b/lib/deployinator/app.rb
@@ -247,7 +247,7 @@ module Deployinator
     get '/:thing' do
       @stack = params[:thing]
 
-      unless Deployinator.get_stacks.include?(@stack)
+      unless Deployinator.get_visible_stacks.include?(@stack)
         raise "No such stack #{@stack}"
       end
 

--- a/lib/deployinator/controller.rb
+++ b/lib/deployinator/controller.rb
@@ -43,6 +43,8 @@ module Deployinator
       end
     end
 
+    attr_accessor :filename
+
     def get_filename
       @filename
     end
@@ -132,6 +134,12 @@ module Deployinator
       if state.nil? || !state.is_a?(Hash)
         state = {}
       end
+
+      state.merge!(
+        :deploy_instance  => deploy_instance,
+        :filename         => deploy_instance.get_filename,
+      )
+
       deploy_instance.raise_event(:deploy_end, state)
 
       if options[:method].match(/config_push/)
@@ -151,6 +159,8 @@ module Deployinator
 
       deploy_instance.unlock_pushes(options[:stack])
       deploy_instance.move_stack_logfile(options[:stack])
+
+      deploy_instance.raise_event(:log_file_retired, state)
 
       return deploy_instance
     end

--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -447,7 +447,7 @@ module Deployinator
     # Returns an array of hashes with the fields "stack" and "current"
     # where "current" is true for the currently selected stack.
     def get_stack_select
-      stacks = Deployinator.get_stacks
+      stacks = Deployinator.get_visible_stacks
       output = Array.new
       stacks.each do |s|
         current = stack == s

--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -6,6 +6,14 @@ require 'deployinator/helpers/plugin'
 
 module Deployinator
   module Helpers
+    class CommandContainsNewlinesError < StandardError
+      attr_accessor :original_command
+
+      def initialize(original_command = nil)
+        self.original_command = original_command
+      end
+    end
+
     include Deployinator::Helpers::VersionHelpers,
       Deployinator::Helpers::PluginHelpers
 
@@ -132,6 +140,20 @@ module Deployinator
       end
 
       raise "Unable to execute `#{cmd}` after retrying #{num_retries} times"
+    end
+
+    def check_command_safety(command)
+      if command.include? "\n"
+        raise CommandContainsNewlinesError.new(command),
+          "Command contains newlines and may not execute as intended: #{command}"
+      end
+
+      command
+    end
+
+    def run_cmd_safely(command, timing_metric = nil, log_errors = true)
+      command = check_command_safety(command)
+      run_cmd(command, timing_metric, log_errors)
     end
 
     # Run external command with timing information

--- a/lib/deployinator/plugins/delete_log.rb
+++ b/lib/deployinator/plugins/delete_log.rb
@@ -1,0 +1,39 @@
+require 'deployinator/plugin'
+require 'deployinator/helpers'
+
+=begin
+This plugin enables deploys to optionally delete the log file they just generated.
+
+Add the plugin to the stack as you normally would (either globally, or for that stack specifically).
+And modify the return hash of the deploy method to include a truthy value for :should_delete_log
+
+A great usecase for this functionality is with a 'cron deploy'. Imagine you have a deploy that
+spins up every minute and checks whether it needs to actually perform an action or not. The vast majority
+of the time, the deploy has nothing to do and generates an empty log. In those cases, you KNOW that the deploy
+has nothing to do. So you tell the plugin to delete the log as not to clutter your Deployinator host with
+thousands of empty log files as compared to only a few with actual actions.
+=end
+
+module Deployinator
+  class DeleteLog < Plugin
+    include Helpers
+
+    def run(event, state)
+      case event
+      when :log_file_retired
+        deploy = state[:deploy_instance]
+        filename = state[:filename]
+
+        if state[:should_delete_log] and not filename.to_s.empty?
+          output = File.delete(
+            RUN_LOG_PATH + filename,
+          )
+
+          #we set the filename to nil so that any subsequent log_and_stream's
+          #don't accidentally recreate the log we were asked to delete
+          deploy.filename = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/deployinator/stack-tail.rb
+++ b/lib/deployinator/stack-tail.rb
@@ -25,7 +25,7 @@ module Tailer
 
   # Checks if stack log symlink exists and creates Tailer for it
   def self.stack_tail(stack, channel, channel_count)
-    if Deployinator.get_stacks.include?(stack)
+    if Deployinator.get_visible_stacks.include?(stack)
       filename = "#{Deployinator::Helpers::RUN_LOG_PATH}current-#{stack}"
       start_pos = (channel_count == 0) ? 0 : -1
       File.exists?(filename) ? StackTail.new(filename, channel, start_pos) : false

--- a/lib/deployinator/views/index.rb
+++ b/lib/deployinator/views/index.rb
@@ -10,7 +10,7 @@ module Deployinator::Views
     #
     # Retuns an array of non-pinned stacks!
     def get_other_stack_list
-      Deployinator.get_stacks
+      Deployinator.get_visible_stacks
     end
   end
 end

--- a/test/unit/git_test.rb
+++ b/test/unit/git_test.rb
@@ -64,4 +64,26 @@ class HelpersTest < Test::Unit::TestCase
     # Calling it a second time should just use the cached result on disk
     assert_equal(head_rev_sha, GitHelpers.git_head_rev('some_stack'))
   end
+
+  def test_git_get_head_rev_ls_output
+    good_ls_output = <<-EOM
+    724fe11d3d3afd1fe7e0bfa8cd9f34b90d038599        refs/heads/master
+    EOM
+
+    good_first_10_sha = '724fe11d3d'
+
+    bad_ls_output = <<-EOM
+    724fe11d3d3afd1fe7e0bfa8cd9f34b90d038599        refs/heads/master
+    724fe11d3d3afd1fe7e0bfa8cd9f34b90d038599        refs/heads/origin/master
+    EOM
+
+    assert_equal(
+      good_first_10_sha,
+      GitHelpers.get_git_head_rev_from_ls_output(good_ls_output, 'master')
+    )
+
+    assert_raise(GitHelpers::AmbiguousRemoteBranchesError) do
+      GitHelpers.get_git_head_rev_from_ls_output(bad_ls_output, 'master')
+    end
+  end
 end

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -24,7 +24,7 @@ class HelpersTest < Test::Unit::TestCase
 
     # mock out the run_cmd. this should move.
     Deployinator::Helpers.module_eval do
-      define_method "run_cmd" do |cmd|
+      define_method "run_cmd" do |cmd, arg2 = nil, arg3 = nil|
         return { :stdout => cmd, :exit_code => 0 }
       end
     end

--- a/test/unit/helpers_test.rb
+++ b/test/unit/helpers_test.rb
@@ -133,4 +133,18 @@ class HelpersTest < Test::Unit::TestCase
     Deployinator.admin_groups = ["bar"]
     assert_true(is_admin?(["foo", "bar"], ["bar"]))
   end
+
+  def test_run_cmd_safely
+    safe_command = %Q!cd /var/hudson/.hudson/workspace/EtsyApp!
+    unsafe_command = %Q!cd /var/hudson/.hu\ndson/workspace/EtsyApp!
+
+    assert_equal(
+      {:exit_code => 0, :stdout => safe_command},
+      run_cmd_safely(safe_command)
+    )
+
+    assert_raise Deployinator::Helpers::CommandContainsNewlinesError do
+      run_cmd_safely(unsafe_command)
+    end
+  end
 end


### PR DESCRIPTION
I added an invisible_stacks attribute to hide stacks from the UI. This can be used to create headless stacks.

I've also added two safety pieces related to strings unexpectedly including newlines within their bodies.

Also adds a plugin to be used to automatically delete logs if they're not necessary, which is opt-in.