### PR TITLE
Add option in log_entries for multiple stacks at once

### DIFF
--- a/bin/deployinator-tailer.rb
+++ b/bin/deployinator-tailer.rb
@@ -9,17 +9,17 @@ require 'deployinator/helpers/stack-tail'
 # Note: If you change the protocol of how this communicates with the front end,
 # please also update the version located in helpers/stack-tail.rb
 EM.run do
-  @@tailers = Hash.new
-  @@channels = Hash.new
-  @@channels_count = Hash.new
+  @tailers = Hash.new
+  @channels = Hash.new
+  @channels_count = Hash.new
 
   # reload the list of stacks from Deployinator without affecting
   # existing channels. does not remove stacks that no longer exist`
   def refresh_stacks
     Deployinator.get_visible_stacks.each do |stack|
-      unless @@channels.key?(stack)
-        @@channels[stack] = EM::Channel.new
-        @@channels_count[stack] = 0
+      unless @channels.key?(stack)
+        @channels[stack] = EM::Channel.new
+        @channels_count[stack] = 0
       end
     end
   end
@@ -33,10 +33,10 @@ EM.run do
     # This attempts to attach a tailer to the stack symlink. If it doesn't
     # exist yet it will attempt next tick of the EventMachine
     def attach_tailer(stack)
-      if @@channels.key?(stack) 
-        tailer = Tailer.stack_tail(stack, @@channels[stack], @@channels_count[stack])
+      if @channels.key?(stack)
+        tailer = Tailer.stack_tail(stack, @channels[stack], @channels_count[stack])
         if tailer
-          @@tailers[stack] = tailer
+          @tailers[stack] = tailer
         else
           EM.next_tick do
             attach_tailer(stack)
@@ -51,24 +51,24 @@ EM.run do
       ws.send(Deployinator::Helpers::StackTailHelpers::get_stack_tail_version())
 
       ws.onclose do
-        if stack && @@channels.key?(stack)
-          @@channels[stack].unsubscribe(session_id)
-          @@channels_count[stack] -= 1
-          if @@channels_count[stack] == 0 && @@tailers.has_key?(stack)
-            @@tailers[stack].close 
-            @@tailers.delete(stack)
+        if stack && @channels.key?(stack)
+          @channels[stack].unsubscribe(session_id)
+          @channels_count[stack] -= 1
+          if @channels_count[stack] == 0 && @tailers.has_key?(stack)
+            @tailers[stack].close
+            @tailers.delete(stack)
           end
         end
       end
 
       ws.onmessage do |msg|
         stack = msg
-        if @@channels.key?(stack)
-          unless @@tailers.key?(stack)
+        if @channels.key?(stack)
+          unless @tailers.key?(stack)
             attach_tailer(stack)
           end
-          @@channels_count[stack] += 1
-          session_id = @@channels[stack].subscribe do |data|
+          @channels_count[stack] += 1
+          session_id = @channels[stack].subscribe do |data|
             ws.send(data)
           end
         end


### PR DESCRIPTION
Currently there is not an option to retrieve log entries across multiple stacks with one call. You can get around this by passing in something like the following for the "stack" option 

> "stack1|stack2|stack3"

However, this is bad practice as it relies on knowing the implementation of log_entries, and that could also be changed. This pull request is to add an option called "stacks" to log_entries that is an array of stacks to grab entries from. The original option "stack" is untouched so this is backwards compatible with any use of log_entries. 
