### PR TITLE
Fix monkey patch conditionals

### DIFF
--- a/lib/deployinator/base.rb
+++ b/lib/deployinator/base.rb
@@ -42,7 +42,7 @@ class Mustache
 end
 
 # Ruby 1.8.6 is teh LAMEZ0Rz
-unless Symbol.respond_to?(:to_proc)
+unless Symbol.method_defined?(:to_proc)
   class Symbol
     def to_proc
       Proc.new { |obj, *args| obj.send(self, *args) }
@@ -50,7 +50,7 @@ unless Symbol.respond_to?(:to_proc)
   end
 end
 
-unless String.respond_to?(:start_with?)
+unless String.method_defined?(:start_with?)
   class String
     def start_with?(str)
       self.index(str) == 0


### PR DESCRIPTION
These monkey patches were always being applied because `respond_to?` checks if the class implements the method. Switching to `method_defined?` correctly tests whether *instances* of the class implement the method.