### PR TITLE
Add more helpful Error messages

### DIFF
--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -322,7 +322,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                     });
 
                     if (error_deploying) {
-                      alert('Error processing your request. There might be a deploy in progress. Please refresh the page and try again in a moment.');
+                      alert("Error processing your request. There might be a deploy in progress. Please refresh the page and try again in a moment.");
                       is_deploying = false;
                       enableDeploys();
                       return false;

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -113,6 +113,9 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                             if (form.length == 1) {
                                 stream_log_websocket(form[0]);
                             }
+                        },
+                        error: function (xhrObj, textStatus, errorThrown) {
+                            alert("Error processing your request. Please refresh the page. If this problem persists contact an admin.");
                         }
                     });
                 });
@@ -313,7 +316,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                         async: false,  // makes the parent wait for the response
                         success: function (data) {
                         },
-                        error: function (data) {
+                        error: function (xhrObj, textStatus, errorThrown) {
                           error_deploying = true;
                         }
                     });
@@ -350,7 +353,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                                 success: function (data) {
                                     ircnick = data['irc_nick'];
                                 },
-                                error: function (data) {
+                                error: function (xhrObj, textStatus, errorThrown) {
                                     ircnick = deployer;
                                 }
                             });

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -319,7 +319,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                     });
 
                     if (error_deploying) {
-                      alert('There was an error deploying. Please try again in a moment or there is already a deploy going');
+                      alert('Error processing your request. There might be a deploy in progress. Please refresh the page and try again in a moment.');
                       is_deploying = false;
                       enableDeploys();
                       return false;
@@ -456,6 +456,9 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                                             addStackLockStatus(data.method, data.who, data.lock_time);
                                         }
                                     }
+                                },
+                                error: function (xhrObj, textStatus, errorThrown) {
+                                    alert("Error getting the deploy status. Please refresh the page. If this problem persists contact an admin.");
                                 }
                             });
                         }


### PR DESCRIPTION
An error when trying to access the 'can-deploy' stack page (which updates the deploy status and appearance of buttons) can be due to authentication. Refreshing the page will prompt for authentication and fix this issue, but this wasn't entirely clear from the error message which made it seem that there was a problem with the deploy.

This will fix the problem by prompting the user to refresh if there is an error. 