### PR TITLE
Add a link to the Deployinator Runbook help page

### DIFF
--- a/lib/deployinator.rb
+++ b/lib/deployinator.rb
@@ -16,6 +16,9 @@ module Deployinator
     # Hostname where deployinator runs
     attr_accessor :hostname
 
+    # Link to a help page
+    attr_accessor :help_url
+
     # Default username for passwordless ssh
     attr_accessor :default_user
 

--- a/lib/deployinator/helpers.rb
+++ b/lib/deployinator/helpers.rb
@@ -31,6 +31,14 @@ module Deployinator
       RUN_LOG_PATH
     end
 
+    def help_url?
+      ! Deployinator.help_url.nil?
+    end
+
+    def help_url
+      "#{Deployinator.help_url}"
+    end
+
     def init(env)
       @username = 'nobody'
       @groups = ['nogroup']

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -68,7 +68,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                    {{#help_url?}}
                    <div class="line">
                        <span class="label">Deployinator Help: </span>
-                       <span><a href="{{ help_url }}">"{{help_url}}"</a></span>
+                       <span><a href="{{ help_url }}">{{help_url}}</a></span>
                    </div>
                    {{/help_url?}}
                </div>

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -68,7 +68,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                    {{#help_url?}}
                    <div class="line">
                        <span class="label">Deployinator Help: </span>
-                       <span><a href="{{ help_url }}">Help</a></span>
+                       <span><a href="{{ help_url }}">"{{help_url}}"</a></span>
                    </div>
                    {{/help_url?}}
                </div>

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -67,7 +67,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                    </div>
                    {{#help_url?}}
                    <div class="line">
-                       <span><a href="{{ help_url }}" target="_blank">Deployinator Help</a></span>
+                       <span><a href="{{ help_url }}" target="_blank">Deployinator Runbook</a></span>
                    </div>
                    {{/help_url?}}
                </div>

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -67,8 +67,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                    </div>
                    {{#help_url?}}
                    <div class="line">
-                       <span class="label">Deployinator Help: </span>
-                       <span><a href="{{ help_url }}" target="_blank">{{help_url}}</a></span>
+                       <span><a href="{{ help_url }}" target="_blank">Deployinator Help</a></span>
                    </div>
                    {{/help_url?}}
                </div>

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -67,6 +67,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                    </div>
                    {{#help_url?}}
                    <div class="line">
+                       <span class="label">Help: </span>
                        <span><a href="{{ help_url }}" target="_blank">Deployinator Runbook</a></span>
                    </div>
                    {{/help_url?}}

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -68,7 +68,7 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                    {{#help_url?}}
                    <div class="line">
                        <span class="label">Deployinator Help: </span>
-                       <span><a href="{{ help_url }}">{{help_url}}</a></span>
+                       <span><a href="{{ help_url }}" target="_blank">{{help_url}}</a></span>
                    </div>
                    {{/help_url?}}
                </div>

--- a/lib/deployinator/templates/layout.mustache
+++ b/lib/deployinator/templates/layout.mustache
@@ -65,6 +65,12 @@ _  __  / _  _ \___  __ \__  / _  __ \__  / / /__  / __  __ \_  __ `/_  __/_  __ 
                        <span class="label">Current Deploys: </span>
                        <span><a title="Wm5sb3JMYmhGdWJoeXFPYmJncG56Y1ZhRnJwaGV2Z2w=" href= "/deploys_status">Watch</a></span>
                    </div>
+                   {{#help_url?}}
+                   <div class="line">
+                       <span class="label">Deployinator Help: </span>
+                       <span><a href="{{ help_url }}">Help</a></span>
+                   </div>
+                   {{/help_url?}}
                </div>
             </header>
 


### PR DESCRIPTION
Add a link to the Deployinator runbook help page from the top of the main Deployinator header.