### PR TITLE
Force UTF-8 in stack-tail.rb

### DIFF
--- a/lib/deployinator/stack-tail.rb
+++ b/lib/deployinator/stack-tail.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require "em-websocket"
 require "eventmachine-tail"
 
@@ -12,11 +13,13 @@ module Tailer
       @buffer = BufferedTokenizer.new
     end
 
-    # This method is called whenever FileTail receives and inotify event for
+    # This method is called whenever FileTail receives an inotify event for
     # the tailed file. It breaks up the data per line and pushes a line at a
     # time. This is to prevent the last javascript line from being broken up
     # over 2 pushes thus breaking the eval on the front end.
     def receive_data(data)
+      # replace non UTF-8 characters with ?
+      data.encode!('UTF-8', invalid: :replace, undef: :replace, replace: '�')
       @buffer.extract(data).each do |line|
         @channel.push line
       end


### PR DESCRIPTION
This change will cause the stack tailer to replace all non UTF-8 characters in the deploy log. Currently it throws an exception when the stack tail method attempts to parse invalid or unknown UTF-8 characters.

Console output displaying before/after:
<img width="793" alt="screen shot 2018-03-13 at 7 32 22 pm" src="https://user-images.githubusercontent.com/6979906/37375556-80ab33da-26f6-11e8-9b05-096d1fcdb162.png">
