### PR TITLE
Remove references to undeclared argument and add ability to specify version file name

### DIFF
--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -48,7 +48,7 @@ module Deployinator
       #
       #
       # Returns STDOUT of the echo command
-      def git_bump_version(stack, version_dir, extra_cmd="", path, rev="HEAD", tee_cmd="tee", version_file="version.txt")
+      def git_bump_version(stack, version_dir, extra_cmd, path, rev="HEAD", tee_cmd="tee", version_file="version.txt")
         unless version_dir.kind_of?(Array)
           version_dir = [version_dir]
         end
@@ -102,7 +102,7 @@ module Deployinator
       # branch    - the branch to checkout after the fetch
       #
       # Returns a hash containing the stdout and return code of the git commands
-      def git_freshen_clone(stack, extra_cmd="", path, branch="master", force_checkout=false)
+      def git_freshen_clone(stack, extra_cmd, path, branch="master", force_checkout=false)
         cmd = [
           "cd #{path}",
           "git fetch --quiet origin +refs/heads/#{branch}:refs/remotes/origin/#{branch}",
@@ -247,7 +247,7 @@ module Deployinator
       # branch        - Git branch to checkout. Defaults to 'master'.
       #
       # Returns a hash containing the stdout and return code of the git commands
-      def git_clone(stack, repo_url, extra_cmd="", checkout_root, branch='master')
+      def git_clone(stack, repo_url, extra_cmd, checkout_root, branch='master')
         path =  git_checkout_path(checkout_root, stack)
         cmd = "git clone #{repo_url} -b #{branch} #{path}"
         cmd = build_git_cmd(cmd, extra_cmd)

--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -46,14 +46,12 @@ module Deployinator
       #
       #
       # Returns STDOUT of the echo command
-      def git_bump_version(stack, version_dir, extra_cmd="", path=nil, rev="HEAD", tee_cmd="tee")
+      def git_bump_version(stack, version_dir, extra_cmd="", path, rev="HEAD", tee_cmd="tee")
         unless version_dir.kind_of?(Array)
           version_dir = [version_dir]
         end
 
         ts = Time.now.strftime("%Y%m%d-%H%M%S-%Z")
-
-        path ||= git_checkout_path(checkout_root, stack)
 
         cmd = "cd #{path} && git rev-parse --short=#{Deployinator.git_sha_length} #{rev}"
         cmd = build_git_cmd(cmd, extra_cmd)
@@ -102,8 +100,7 @@ module Deployinator
       # branch    - the branch to checkout after the fetch
       #
       # Returns a hash containing the stdout and return code of the git commands
-      def git_freshen_clone(stack, extra_cmd="", path=nil, branch="master", force_checkout=false)
-        path ||= git_checkout_path(checkout_root, stack)
+      def git_freshen_clone(stack, extra_cmd="", path, branch="master", force_checkout=false)
         cmd = [
           "cd #{path}",
           "git fetch --quiet origin +refs/heads/#{branch}:refs/remotes/origin/#{branch}",
@@ -160,8 +157,7 @@ module Deployinator
       # including     - Should the returned list of filters include the filter_file commits, or all other commits
       #
       # Returns an array of shas
-      def git_filter_shas(stack, extra_cmd, old_rev, new_rev, path=nil, filter_files=[], including=false)
-        path ||= git_checkout_path(checkout_root, stack)
+      def git_filter_shas(stack, extra_cmd, old_rev, new_rev, path, filter_files=[], including=false)
         including_shas = []
         excluding_shas = []
         cmd = "cd #{path} && git log --no-merges --name-only --pretty=format:%H #{old_rev}..#{new_rev}"
@@ -249,8 +245,8 @@ module Deployinator
       # branch        - Git branch to checkout. Defaults to 'master'.
       #
       # Returns a hash containing the stdout and return code of the git commands
-      def git_clone(stack, repo_url, extra_cmd="", local_checkout_root=checkout_root, branch='master')
-        path =  git_checkout_path(local_checkout_root, stack)
+      def git_clone(stack, repo_url, extra_cmd="", checkout_root, branch='master')
+        path =  git_checkout_path(checkout_root, stack)
         cmd = "git clone #{repo_url} -b #{branch} #{path}"
         cmd = build_git_cmd(cmd, extra_cmd)
         run_cmd cmd

--- a/lib/deployinator/helpers/git.rb
+++ b/lib/deployinator/helpers/git.rb
@@ -33,20 +33,22 @@ module Deployinator
       # Public: method to get the short rev of a git commit and create a
       # version tag from it. The tag is then dumped into a version text file.
       #
-      # stack       - String representing the stack, which determines where the
-      #               version file should be located
-      # version_dir - String (or Array of Strings) representing the
-      #               directories to contain the version file
-      # extra_cmd   - String representing an additional command to prepend to
-      #               the version echo command (default: "")
-      # path        - String containing the base path where the version file is
-      #               located (default: nil)
-      # rev         - String containing the rev to parse for the short SHA id
-      #               (default: "HEAD")
+      # stack        - String representing the stack, which determines where the
+      #                version file should be located
+      # version_dir  - String (or Array of Strings) representing the
+      #                directories to contain the version file
+      # extra_cmd    - String representing an additional command to prepend to
+      #                the version echo command (default: "")
+      # path         - String containing the base path where the version file is
+      #                located (default: nil)
+      # rev          - String containing the rev to parse for the short SHA id
+      #                (default: "HEAD")
+      # version_file - String representing the name of the file to contain
+      #                the version
       #
       #
       # Returns STDOUT of the echo command
-      def git_bump_version(stack, version_dir, extra_cmd="", path, rev="HEAD", tee_cmd="tee")
+      def git_bump_version(stack, version_dir, extra_cmd="", path, rev="HEAD", tee_cmd="tee", version_file="version.txt")
         unless version_dir.kind_of?(Array)
           version_dir = [version_dir]
         end
@@ -61,7 +63,7 @@ module Deployinator
 
         fullpaths = ""
         version_dir.each do |dir|
-          fullpath = File.join(dir, "version.txt")
+          fullpath = File.join(dir, version_file)
           fullpaths << fullpath + " "
         end
 

--- a/lib/deployinator/helpers/version.rb
+++ b/lib/deployinator/helpers/version.rb
@@ -24,9 +24,9 @@ module Deployinator
       # host - String of the hostname to check
       #
       # Returns the full version of the current software running on the host
-      def get_version(host)
+      def get_version(host, version_file="version.txt")
         host_url = "https://#{host}/"
-        get_version_by_url("#{host_url}version.txt")
+        get_version_by_url("#{host_url}#{version_file}")
       end
       module_function :get_version
 


### PR DESCRIPTION
There are a number of places in the git helper that reference ```checkout_root``` which isn't declared anywhere (some methods have it as an argument but others do not). The proposed fix for this is to make ```path``` a required argument instead of defaulting to ```nil``` so that the checkout path doesn't need to be inferred. In fact, the path can't be inferred anyway because ```checkout_root``` isn't declared in the methods being adjusted.

To make this work, it was necessary to remove the default value for the ```extra_cmd``` argument which immediately precedes the ```path``` argument, however since leaving a default ```nil``` value for ```path``` would cause an exception, I think it's safe to assume that users are also supplying a value for ```extra_cmd```.

This also gives users the ability to specify the name of the version file if they so desire.