### PR TITLE
Don't just show "Deploy completed" if an exception happened

### DIFF
--- a/lib/deployinator/controller.rb
+++ b/lib/deployinator/controller.rb
@@ -118,8 +118,8 @@ module Deployinator
       end
 
       @start_time = Time.now
-      deploy_instance.log_and_stream "Push started at #{@start_time.to_i}\n"
-      deploy_instance.log_and_stream "Calling #{options[:method]}\n";
+      deploy_instance.log_and_stream "Push started at #{@start_time.to_i}<br>"
+      deploy_instance.log_and_stream "Calling #{options[:method]}<br>";
       deploy_instance.link_stack_logfile(deploy_instance.get_filename, options[:stack])
 
       deploy_instance.raise_event(:deploy_start)

--- a/lib/deployinator/controller.rb
+++ b/lib/deployinator/controller.rb
@@ -153,8 +153,13 @@ module Deployinator
 
       # display a message that the deploy is done and call the JavaScript
       # deploy done function
-      msg = options[:deploy_complete_message] || "#{env.to_s.upcase} deploy in #{options[:stack]} stack complete"
-      deploy_instance.log_and_stream("<h4>#{msg}</h4><p class='output'>")
+      msg = ''
+      if state[:exception]
+        msg = "ERROR: #{state[:exception].message}"
+      else
+        msg = options[:deploy_complete_message] || "#{env.to_s.upcase} deploy in #{options[:stack]} stack complete"
+        deploy_instance.log_and_stream("<h4>#{msg}</h4><p class='output'>")
+      end
       deploy_instance.log_and_stream("<script id='deploy-done'>window.deploy_done('#{msg}', '#{options[:stage]}');</script>")
 
       deploy_instance.unlock_pushes(options[:stack])


### PR DESCRIPTION
It can be very misleading to have a "... stack complete." message at the end of a deploy when an exception happens during the deploy. There's no way to set the ```deploy_complete_message``` once a deploy has started so this change will set the message displayed at the end of a deploy to the message of an exception if an exception exists in `state`.

Ideally, there would be no informational panel if there is an exception and only the error pane would be displayed but that would require a lot more changes to make happen so this seems like a good compromise.