### PR TITLE
Add `censor_cmd` to helpers and have `run_cmd` use it

### DIFF
--- a/lib/deployinator/helpers/dsh.rb
+++ b/lib/deployinator/helpers/dsh.rb
@@ -14,10 +14,10 @@ module Deployinator
         groups.map {|group| "-g #{group} "}.join("")
       end
 
-      def run_dsh(groups, cmd, only_stdout=true, timing_metric=nil, log_errors=true, ignore_failure=false, &block)
+      def run_dsh(groups, cmd, only_stdout=true, timing_metric=nil, log_errors=true, ignore_failure=false, secrets=[], &block)
         dsh_groups = group_option_for_dsh(groups)
         ignore_failure = ignore_failure ? ignore_failure_command : ""
-        cmd_return = run_cmd(%Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} dsh #{dsh_groups} -r ssh -F #{dsh_fanout} "#{cmd}"#{ignore_failure}}, timing_metric, log_errors, &block)
+        cmd_return = run_cmd(%Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} dsh #{dsh_groups} -r ssh -F #{dsh_fanout} "#{cmd}"#{ignore_failure}}, timing_metric, log_errors, secrets, &block)
         if only_stdout
           cmd_return[:stdout]
         else
@@ -26,20 +26,20 @@ module Deployinator
       end
 
       # run dsh against a given host or array of hosts
-      def run_dsh_hosts(hosts, cmd, extra_opts='', only_stdout=true, timing_metric=nil, log_errors=true, ignore_failure=false, &block)
+      def run_dsh_hosts(hosts, cmd, extra_opts='', only_stdout=true, timing_metric=nil, log_errors=true, ignore_failure=false, secrets=[], &block)
         hosts = [hosts] unless hosts.is_a?(Array)
         ignore_failure = ignore_failure ? ignore_failure_command : ""
         if extra_opts.length > 0
-          run_cmd %Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} 'dsh -m #{hosts.join(',')} -r ssh -F #{dsh_fanout} #{extra_opts} -- "#{cmd}"#{ignore_failure}'}, timing_metric, log_errors, &block
+          run_cmd %Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} 'dsh -m #{hosts.join(',')} -r ssh -F #{dsh_fanout} #{extra_opts} -- "#{cmd}"#{ignore_failure}'}, timing_metric, log_errors, secrets, &block
         else
-          run_cmd %Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} 'dsh -m #{hosts.join(',')} -r ssh -F #{dsh_fanout} -- "#{cmd}" #{ignore_failure}'}, timing_metric, log_errors, &block
+          run_cmd %Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} 'dsh -m #{hosts.join(',')} -r ssh -F #{dsh_fanout} -- "#{cmd}" #{ignore_failure}'}, timing_metric, log_errors, secrets, &block
         end
       end
 
-      def run_dsh_extra(groups, cmd, extra_opts, only_stdout=true, timing_metric=nil, log_errors=true, ignore_failure=false, &block)
+      def run_dsh_extra(groups, cmd, extra_opts, only_stdout=true, timing_metric=nil, log_errors=true, ignore_failure=false, secrets=[], &block)
         dsh_groups = group_option_for_dsh(groups)
         ignore_failure = ignore_failure ? ignore_failure_command : ""
-        cmd_return = run_cmd(%Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} dsh #{dsh_groups} -r ssh #{extra_opts} -F #{dsh_fanout} "#{cmd}"#{ignore_failure} }, timing_metric, log_errors, &block)
+        cmd_return = run_cmd(%Q{ssh #{Deployinator.default_user}@#{Deployinator.deploy_host} dsh #{dsh_groups} -r ssh #{extra_opts} -F #{dsh_fanout} "#{cmd}"#{ignore_failure} }, timing_metric, log_errors, secrets, &block)
         if only_stdout
           cmd_return[:stdout]
         else


### PR DESCRIPTION
This adds a `censor_cmd` method to the helpers modules, and modifies `run_cmd` and most callers
of that to take a `secrets` array argument, the values of which will be censored in the log output.

A basic test for `censor_cmd` is provided, but it is beyond my ken to do a proper test of the
output from `run_cmd` in the tests.