### PR TITLE
Add characterization tests for helpers.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,10 @@ def command?(command)
   system("type #{command} &> /dev/null")
 end
 
+task :default => 'test:unit'
+
 namespace :test do
+  task :default => 'deployinator:test:unit'
   task :character => 'deployinator:test:character'
   task :unit => 'deployinator:test:unit'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,6 @@ end
 
 task :default => 'deployinator:test:unit'
 
+task :character => 'deployinator:test:character'
+
 load 'deployinator/tasks/tests.rake'

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,9 @@ def command?(command)
   system("type #{command} &> /dev/null")
 end
 
-task :default => 'deployinator:test:unit'
-
-task :character => 'deployinator:test:character'
+namespace :test do
+  task :character => 'deployinator:test:character'
+  task :unit => 'deployinator:test:unit'
+end
 
 load 'deployinator/tasks/tests.rake'

--- a/lib/deployinator/tasks/tests.rake
+++ b/lib/deployinator/tasks/tests.rake
@@ -18,5 +18,12 @@ namespace :deployinator do
       t.pattern = "#{File.dirname(__FILE__)}/../../../test/functional/**/*_test.rb"
       t.verbose = false
     end
+
+    desc 'Run deployinator characterization tests'
+    Rake::TestTask.new :character do |t|
+      t.libs << 'lib'
+      t.pattern = "#{File.dirname(__FILE__)}/../../../test/character/**/*_test.rb"
+      t.verbose = false
+    end
   end
 end

--- a/test/character/deployinator_helpers_test.rb
+++ b/test/character/deployinator_helpers_test.rb
@@ -1,0 +1,65 @@
+require 'test/unit'
+require 'mocha/test_unit'
+require 'open3'
+
+require File.expand_path('../../lib/deployinator/helpers.rb',__dir__)
+
+class DeployinatorHelpersTest < Test::Unit::TestCase
+
+  def test_run_cmd_succeeds
+    # arrange
+    cmd = 'dummy_command_exits_with_success'
+
+    deployinator_helper = Class.new.extend(Deployinator::Helpers)
+    deployinator_helper.expects(:run_cmd)
+      .returns({
+        :exit_code => 0
+      })
+      .once
+
+    # act
+    actual = deployinator_helper.run_cmd(cmd)
+
+    # assert
+    assert_equal({:exit_code => 0}, actual)
+  end
+
+  def test_run_cmd_fails_while_log_errors_is_false
+    # arrange
+    cmd = 'echo -n epicfail && exit 1'
+    deployinator_helper = Class.new.extend(Deployinator::Helpers)
+    deployinator_helper.expects(:log_and_stream).times(5)
+    log_errors = false
+
+    expected = {
+      :exit_code => 1,
+      :stdout => 'epicfail'
+    }
+
+    # act
+    actual = deployinator_helper.run_cmd(cmd, nil, log_errors)
+
+    # assert
+    assert_equal(expected, actual)
+  end
+
+  def test_run_cmd_fails_while_log_errors_is_true
+    # arrange
+    cmd = 'echo -n epicfail && exit 1'
+    deployinator_helper = Class.new.extend(Deployinator::Helpers)
+    deployinator_helper.expects(:log_and_stream).times(5)
+    log_errors = true
+
+    expected = {
+      :exit_code => 1,
+      :stdout => 'epicfail'
+    }
+
+    # act
+    actual = deployinator_helper.run_cmd(cmd, nil, log_errors)
+
+    # assert
+    assert_equal(expected, actual)
+  end
+
+end

--- a/test/character/deployinator_helpers_test.rb
+++ b/test/character/deployinator_helpers_test.rb
@@ -6,22 +6,14 @@ require File.expand_path('../../lib/deployinator/helpers.rb',__dir__)
 
 class DeployinatorHelpersTest < Test::Unit::TestCase
 
-  def test_run_cmd_succeeds
+  def test_run_cmd_calls_popen3_once_with_expected_command
     # arrange
-    cmd = 'dummy_command_exits_with_success'
-
+    cmd = 'fakecommand'
     deployinator_helper = Class.new.extend(Deployinator::Helpers)
-    deployinator_helper.expects(:run_cmd)
-      .returns({
-        :exit_code => 0
-      })
-      .once
+    Open3.expects(:popen3).with(cmd).once
 
-    # act
-    actual = deployinator_helper.run_cmd(cmd)
-
-    # assert
-    assert_equal({:exit_code => 0}, actual)
+    # act & assert
+    deployinator_helper.run_cmd(cmd)
   end
 
   def test_run_cmd_fails_while_log_errors_is_false


### PR DESCRIPTION
This PR adds characterization tests for `run_cmd` behavior.

The tests can be run via `rake character`.